### PR TITLE
ci: Update base href for flutter gh-pages

### DIFF
--- a/.github/workflows/web-main.yaml
+++ b/.github/workflows/web-main.yaml
@@ -40,7 +40,7 @@ jobs:
     - run: |
         flutter build web \
         --release \
-        --base-href "/post-disaster-comms/" \
+        --base-href "/resilience/" \
         --web-renderer html \
         --dart-define=SUPABASE_ANON_KEY=${{ secrets.CLOUD_DB_JWT_ANON_KEY}} \
         --dart-define=SUPABASE_URL=${{ secrets.CLOUD_DB_URL}} 


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/web-main.yaml` file. The change updates the base href for the Flutter web build command.

* [`.github/workflows/web-main.yaml`](diffhunk://#diff-a3f8bd0162b14f6fb1afb8f86d38616de0c34882b62e124baedc0701aba57027L43-R43): Changed the `--base-href` parameter from `"/post-disaster-comms/"` to `"/resilience/"` in the Flutter build web command.