### PR TITLE
ci: try fixing test pypi failure by bumping version of dependent action

### DIFF
--- a/.github/workflows/cd_support_sphere_py.yml
+++ b/.github/workflows/cd_support_sphere_py.yml
@@ -57,7 +57,7 @@ jobs:
           ls -ltrh
           ls -ltrh dist
       - name: Publish to Test PyPI
-        uses: pypa/gh-action-pypi-publish@v1.9.0
+        uses: pypa/gh-action-pypi-publish@v1.12.3
         with:
           repository-url: https://test.pypi.org/legacy/
           verbose: true


### PR DESCRIPTION
Trying to fix the issue encountered here: https://github.com/UW-THINKlab/resilience/actions/runs/12602498317/job/35125711800 

Based on whats in here, I feel like this could work? Will revert if this experiment ends in the same failure again: https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.12.3

based on similar issue being reported here: https://github.com/pypa/gh-action-pypi-publish/issues/310